### PR TITLE
Correct hook reference

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -323,7 +323,7 @@ sub _build_wrapper {
     return sub {
         my $user = logged_in_user($dsl);
         if (!$user) {
-            $dsl->execute_hook('login_required', $coderef);
+            $dsl->execute_hook('require_login', $coderef);
             # TODO: see if any code executed by that hook set up a response
             return $dsl->redirect($dsl->uri_for(
                 $loginpage,


### PR DESCRIPTION
If a user entered the URL of a page that required a role, but was not logged in, a 500 resulted, when what should happen is that they are redirected to the login page for login, prior to going to the desired page. This patch corrects the behavior.